### PR TITLE
Mirror local video 

### DIFF
--- a/src/client/components/App.js
+++ b/src/client/components/App.js
@@ -75,6 +75,7 @@ export default class App extends React.PureComponent {
             stream={streams[constants.ME]}
             userId={constants.ME}
             muted
+            mirrored
           />
 
           {_.map(peers, (_, userId) => (

--- a/src/client/components/Video.js
+++ b/src/client/components/Video.js
@@ -16,10 +16,12 @@ export default class Video extends React.PureComponent {
     active: PropTypes.bool.isRequired,
     stream: StreamPropType,
     userId: PropTypes.string.isRequired,
-    muted: PropTypes.bool.isRequired
+    muted: PropTypes.bool.isRequired,
+    mirrored: PropTypes.bool
   }
   static defaultProps = {
-    muted: false
+    muted: false,
+    mirrored: false
   }
   handleClick = e => {
     const { onClick, userId } = this.props
@@ -48,8 +50,8 @@ export default class Video extends React.PureComponent {
     videos[socket.id] = video
   }
   render () {
-    const { active, muted } = this.props
-    const className = classnames('video-container', { active })
+    const { active, mirrored, muted } = this.props
+    const className = classnames('video-container', { active, mirrored })
     return (
       <div className={className}>
         <video

--- a/src/client/components/__tests__/Video-test.js
+++ b/src/client/components/__tests__/Video-test.js
@@ -1,5 +1,6 @@
 jest.mock('../../window.js')
 import React from 'react'
+import ReactDOM from 'react-dom'
 import TestUtils from 'react-dom/test-utils'
 import Video from '../Video.js'
 import { MediaStream } from '../../window.js'
@@ -19,30 +20,40 @@ describe('components/Video', () => {
         stream={this.state.stream || this.props.stream}
         onClick={this.props.onClick}
         userId="test"
+        muted={this.props.muted}
+        mirrored={this.props.mirrored}
       />
     }
   }
 
-  let component, videos, video, onClick, mediaStream, url
-  function render () {
+  let component, videos, video, onClick, mediaStream, url, wrapper
+  function render (flags={}) {
     videos = {}
     onClick = jest.fn()
     mediaStream = new MediaStream()
     component = TestUtils.renderIntoDocument(
       <VideoWrapper
         videos={videos}
-        active
+        active={flags.active || false}
         stream={{ mediaStream, url }}
         onClick={onClick}
         userId="test"
+        muted={flags.muted || false}
+        mirrored={flags.mirrored}
       />
     )
+    wrapper = ReactDOM.findDOMNode(component)
     video = TestUtils.findRenderedComponentWithType(component, Video)
   }
 
   describe('render', () => {
     it('should not fail', () => {
-      render()
+      render({})
+    })
+
+    it('Mirrored and active propogate to rendered classes', () => {
+      render({ active: true, mirrored: true })
+      expect(wrapper.className).toBe('video-container active mirrored')
     })
   })
 

--- a/src/client/components/__tests__/Video-test.js
+++ b/src/client/components/__tests__/Video-test.js
@@ -27,7 +27,7 @@ describe('components/Video', () => {
   }
 
   let component, videos, video, onClick, mediaStream, url, wrapper
-  function render (flags={}) {
+  function render (flags = {}) {
     videos = {}
     onClick = jest.fn()
     mediaStream = new MediaStream()

--- a/src/scss/_video.scss
+++ b/src/scss/_video.scss
@@ -43,4 +43,10 @@
       cursor: inherit;
     }
   }
+
+  .video-container.mirrored video {
+    transform: rotateY(180deg);
+    -webkit-transform:rotateY(180deg);
+    -moz-transform:rotateY(180deg);
+  }
 }


### PR DESCRIPTION
## Overview

Flip the local video horizontally so that it behaves like a mirror.  This is the standard behavior on most video chat applications.

### Screenshot

![peer-chat-mirrored-local](https://user-images.githubusercontent.com/1959820/55763854-b2b0e680-5a1d-11e9-9053-ce2e19bcd7f9.png)

## Test Warnings

As an added bonus, this change clears up a prop type warning the test suite is currently throwing:

### Before

![Screen Shot 2019-04-08 at 4 49 18 PM](https://user-images.githubusercontent.com/1959820/55763968-48e50c80-5a1e-11e9-90f4-73c03e9b7239.png)

### After

![Screen Shot 2019-04-08 at 4 50 22 PM](https://user-images.githubusercontent.com/1959820/55763986-6b772580-5a1e-11e9-9c82-0d1a88659010.png)
